### PR TITLE
Game monitor and leaderboard screens

### DIFF
--- a/lib/screens/bingo_board.dart
+++ b/lib/screens/bingo_board.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'package:amingo/screens/event_details.dart';
-import 'package:amingo/screens/game_monitor.dart';
 import 'package:flutter/material.dart';
 import 'bingo_tile.dart';
 import 'package:amingo/screens/leaderboard_screen.dart';

--- a/lib/screens/bingo_board.dart
+++ b/lib/screens/bingo_board.dart
@@ -3,6 +3,7 @@ import 'package:amingo/screens/event_details.dart';
 import 'package:amingo/screens/game_monitor.dart';
 import 'package:flutter/material.dart';
 import 'bingo_tile.dart';
+import 'package:amingo/screens/leaderboard_screen.dart';
 
 class BingoBoard extends StatefulWidget {
   final String eventName;
@@ -361,14 +362,10 @@ class _BingoBoardState extends State<BingoBoard> {
 
               GestureDetector(
                 onTap: () {
-                  Navigator.pushReplacement(
+                  Navigator.push(
                     context,
                     MaterialPageRoute(
-                      builder: (context) => GameMonitorScreen(
-                        eventName: widget.eventName,
-                        time: (timeLeft / 60).ceil(),
-                        maxParticipants: "60",
-                      ),
+                      builder: (context) => const LeaderboardScreen(),
                     ),
                   );
                 },
@@ -376,7 +373,7 @@ class _BingoBoardState extends State<BingoBoard> {
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     Icon(Icons.bar_chart, color: colorScheme.onSurface),
-                    SizedBox(height: 4),
+                    const SizedBox(height: 4),
                     Text(
                       "RANKS",
                       style: textTheme.labelSmall?.copyWith(

--- a/lib/screens/create_event.dart
+++ b/lib/screens/create_event.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'game_monitor.dart';
+
 class CreateEventScreen extends StatefulWidget {
   const CreateEventScreen({super.key});
   @override
@@ -220,7 +222,23 @@ class _CreateEventScreenState extends State<CreateEventScreen> {
                   width: double.infinity,
                   height: height * 0.07,
                   child: ElevatedButton(
-                    onPressed: () {},
+                      onPressed: () {
+                        if (_eventNameController.text.isNotEmpty &&
+                            _timeLimitController.text.isNotEmpty &&
+                            _participantsController.text.isNotEmpty) {
+
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) => GameMonitorScreen(
+                                eventName: _eventNameController.text,
+                                time: int.parse(_timeLimitController.text),
+                                maxParticipants: _participantsController.text,
+                              ),
+                            ),
+                          );
+                        }
+                      },
                     style: ElevatedButton.styleFrom(
                       backgroundColor: colorScheme.primary,
                       foregroundColor: colorScheme.onPrimary,

--- a/lib/screens/create_event.dart
+++ b/lib/screens/create_event.dart
@@ -222,23 +222,22 @@ class _CreateEventScreenState extends State<CreateEventScreen> {
                   width: double.infinity,
                   height: height * 0.07,
                   child: ElevatedButton(
-                      onPressed: () {
-                        if (_eventNameController.text.isNotEmpty &&
-                            _timeLimitController.text.isNotEmpty &&
-                            _participantsController.text.isNotEmpty) {
-
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                              builder: (context) => GameMonitorScreen(
-                                eventName: _eventNameController.text,
-                                time: int.parse(_timeLimitController.text),
-                                maxParticipants: _participantsController.text,
-                              ),
+                    onPressed: () {
+                      if (_eventNameController.text.isNotEmpty &&
+                          _timeLimitController.text.isNotEmpty &&
+                          _participantsController.text.isNotEmpty) {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => GameMonitorScreen(
+                              eventName: _eventNameController.text,
+                              time: int.parse(_timeLimitController.text),
+                              maxParticipants: _participantsController.text,
                             ),
-                          );
-                        }
-                      },
+                          ),
+                        );
+                      }
+                    },
                     style: ElevatedButton.styleFrom(
                       backgroundColor: colorScheme.primary,
                       foregroundColor: colorScheme.onPrimary,

--- a/lib/screens/create_event.dart
+++ b/lib/screens/create_event.dart
@@ -11,12 +11,14 @@ class _CreateEventScreenState extends State<CreateEventScreen> {
   final TextEditingController _descriptionController = TextEditingController();
   final TextEditingController _timeLimitController = TextEditingController();
   final TextEditingController _participantsController = TextEditingController();
+  final TextEditingController _locationController = TextEditingController();
   @override
   void dispose() {
     _eventNameController.dispose();
     _descriptionController.dispose();
     _timeLimitController.dispose();
     _participantsController.dispose();
+    _locationController.dispose();
     super.dispose();
   }
 
@@ -67,7 +69,7 @@ class _CreateEventScreenState extends State<CreateEventScreen> {
                     ),
                   ),
                 ),
-                SizedBox(height: height * 0.05),
+                SizedBox(height: height * 0.03),
                 Text(
                   "Event Description",
                   style: TextStyle(
@@ -98,7 +100,39 @@ class _CreateEventScreenState extends State<CreateEventScreen> {
                   ),
                 ),
 
-                SizedBox(height: height * 0.05),
+                SizedBox(height: height * 0.03),
+
+                Text(
+                  "Location",
+                  style: TextStyle(
+                    color: colorScheme.primary,
+                    fontSize: width * 0.04,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                SizedBox(height: height * 0.01),
+                TextField(
+                  style: TextStyle(color: colorScheme.onSurface),
+                  cursorColor: colorScheme.primary,
+                  controller: _locationController,
+                  decoration: InputDecoration(
+                    hintText: "Enter the location of the event",
+                    hintStyle: TextStyle(color: colorScheme.onSurfaceVariant),
+                    enabledBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide: BorderSide(color: colorScheme.outline),
+                    ),
+                    focusedBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide: BorderSide(
+                        color: colorScheme.primary,
+                        width: 1.5,
+                      ),
+                    ),
+                  ),
+                ),
+
+                SizedBox(height: height * 0.03),
 
                 Text(
                   "Time Limit",
@@ -140,7 +174,7 @@ class _CreateEventScreenState extends State<CreateEventScreen> {
                     ),
                   ),
                 ),
-                SizedBox(height: height * 0.05),
+                SizedBox(height: height * 0.03),
                 Text(
                   "Maximum Participants",
                   style: TextStyle(

--- a/lib/screens/game_monitor.dart
+++ b/lib/screens/game_monitor.dart
@@ -403,7 +403,6 @@ class _GameMonitorScreenState extends State<GameMonitorScreen> {
             icon: Icon(Icons.emoji_events_rounded, color: colorScheme.primary),
             tooltip: "View Leaderboard",
             onPressed: () {
-              // Make sure to import your leaderboard screen at the top of this file:
               Navigator.push(
                 context,
                 MaterialPageRoute(

--- a/lib/screens/game_monitor.dart
+++ b/lib/screens/game_monitor.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:amingo/screens/leaderboard_screen.dart';
 
 class GameMonitorScreen extends StatefulWidget {
   final String eventName;
@@ -397,6 +398,22 @@ class _GameMonitorScreenState extends State<GameMonitorScreen> {
             letterSpacing: 0.8,
           ),
         ),
+        actions: [
+          IconButton(
+            icon: Icon(Icons.emoji_events_rounded, color: colorScheme.primary),
+            tooltip: "View Leaderboard",
+            onPressed: () {
+              // Make sure to import your leaderboard screen at the top of this file:
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => const LeaderboardScreen(),
+                ),
+              );
+            },
+          ),
+          const SizedBox(width: 8),
+        ],
       ),
       body: SafeArea(
         child: SingleChildScrollView(

--- a/lib/screens/leaderboard_screen.dart
+++ b/lib/screens/leaderboard_screen.dart
@@ -1,0 +1,186 @@
+import 'package:flutter/material.dart';
+import 'package:amingo/widgets/leaderboard_card.dart';
+
+class LeaderboardScreen extends StatelessWidget {
+  const LeaderboardScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final width = MediaQuery.of(context).size.width;
+    final height = MediaQuery.of(context).size.height;
+
+    return Scaffold(
+      appBar: AppBar(
+        centerTitle: true,
+        title: Text(
+          "LEADERBOARD",
+          style: TextStyle(
+            color: colorScheme.primary,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: EdgeInsets.symmetric(horizontal: 18),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Center(
+                  child: Column(
+                    children: [
+                      Stack(
+                        clipBehavior: Clip.none,
+                        alignment: Alignment.center,
+                        children: [
+                          CircleAvatar(radius: width * 0.125),
+                          Positioned(
+                            bottom: -5,
+                            child: Container(
+                              padding: EdgeInsets.symmetric(
+                                horizontal: 10,
+                                vertical: 3,
+                              ),
+                              decoration: BoxDecoration(
+                                color: Colors.yellow,
+                                borderRadius: BorderRadius.circular(12),
+                              ),
+                              child: Text(
+                                "1ST",
+                                style: TextStyle(
+                                  color: Colors.black,
+                                  fontWeight: FontWeight.bold,
+                                  fontSize: 10,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                      SizedBox(height: height * 0.02),
+                      Text(
+                        "Player 1",
+                        style: TextStyle(
+                          color: colorScheme.onSurface,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      Text(
+                        "3222 pts",
+                        style: TextStyle(color: colorScheme.primary),
+                      ),
+                    ],
+                  ),
+                ),
+                Row(
+                  children: [
+                    Column(
+                      children: [
+                        Stack(
+                          clipBehavior: Clip.none,
+                          alignment: Alignment.center,
+                          children: [
+                            CircleAvatar(radius: width * 0.1),
+                            Positioned(
+                              bottom: -5,
+                              child: Container(
+                                padding: EdgeInsets.symmetric(
+                                  horizontal: 10,
+                                  vertical: 3,
+                                ),
+                                decoration: BoxDecoration(
+                                  color: Colors.grey,
+                                  borderRadius: BorderRadius.circular(12),
+                                ),
+                                child: Text(
+                                  "2ND",
+                                  style: TextStyle(
+                                    color: Colors.black,
+                                    fontWeight: FontWeight.bold,
+                                    fontSize: 10,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                        SizedBox(height: height * 0.02),
+                        Text(
+                          "Player 2",
+                          style: TextStyle(
+                            color: colorScheme.onSurface,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        Text(
+                          "2500 pts",
+                          style: TextStyle(color: colorScheme.primary),
+                        ),
+                      ],
+                    ),
+                    SizedBox(width: width * 0.5),
+                    Column(
+                      children: [
+                        Stack(
+                          clipBehavior: Clip.none,
+                          alignment: Alignment.center,
+                          children: [
+                            CircleAvatar(radius: width * 0.085),
+                            Positioned(
+                              bottom: -5,
+                              child: Container(
+                                padding: EdgeInsets.symmetric(
+                                  horizontal: 10,
+                                  vertical: 3,
+                                ),
+                                decoration: BoxDecoration(
+                                  color: Colors.orange,
+                                  borderRadius: BorderRadius.circular(12),
+                                ),
+                                child: Text(
+                                  "3RD",
+                                  style: TextStyle(
+                                    color: Colors.black,
+                                    fontWeight: FontWeight.bold,
+                                    fontSize: 10,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                        SizedBox(height: height * 0.02),
+                        Text(
+                          "Player 3",
+                          style: TextStyle(
+                            color: colorScheme.onSurface,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        Text(
+                          "1500 pts",
+                          style: TextStyle(color: colorScheme.primary),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+                SizedBox(height: height * 0.05),
+                Text(
+                  "GLOBAL RANKING",
+                  style: TextStyle(
+                    color: colorScheme.outline,
+                    fontSize: width * 0.03,
+                  ),
+                ),
+                Center(child: leaderboardCard(context)),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/leaderboard_screen.dart
+++ b/lib/screens/leaderboard_screen.dart
@@ -13,6 +13,7 @@ class LeaderboardScreen extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         centerTitle: true,
+        iconTheme: IconThemeData(color: colorScheme.onSurface),
         title: Text(
           "LEADERBOARD",
           style: TextStyle(

--- a/lib/widgets/activity_card.dart
+++ b/lib/widgets/activity_card.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+Widget activityCard(BuildContext context) {
+  final colorScheme = Theme.of(context).colorScheme;
+  final width = MediaQuery.of(context).size.width;
+  return Container(
+    padding: EdgeInsets.all(12),
+    margin: EdgeInsets.symmetric(vertical: 6),
+    decoration: BoxDecoration(
+      color: colorScheme.surface,
+      border: Border.all(color: colorScheme.outline, width: width * 0.001),
+      borderRadius: BorderRadius.circular(14),
+    ),
+    child: Row(
+      children: [
+        CircleAvatar(radius: 22),
+        SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                "Player 1",
+                style: TextStyle(
+                  color: colorScheme.onSurface,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              Text("Completed Tile A", style: TextStyle(color: Colors.grey)),
+            ],
+          ),
+        ),
+        Column(
+          children: [
+            Text(
+              "1456",
+              style: TextStyle(
+                color: colorScheme.primary,
+                fontSize: width * 0.04,
+              ),
+            ),
+            Text(
+              "PTS",
+              style: TextStyle(color: Colors.grey, fontSize: width * 0.02),
+            ),
+          ],
+        ),
+        IconButton(
+          onPressed: () {},
+          icon: Icon(CupertinoIcons.person_badge_minus, color: Colors.red),
+        ),
+      ],
+    ),
+  );
+}

--- a/lib/widgets/leaderboard_card.dart
+++ b/lib/widgets/leaderboard_card.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+
+Widget leaderboardCard(BuildContext context) {
+  final colorScheme = Theme.of(context).colorScheme;
+  final width = MediaQuery.of(context).size.width;
+
+  return Container(
+    padding: const EdgeInsets.all(12),
+    margin: const EdgeInsets.symmetric(vertical: 6),
+    decoration: BoxDecoration(
+      color: colorScheme.surface,
+      border: Border.all(color: colorScheme.outline, width: width * 0.001),
+      borderRadius: BorderRadius.circular(14),
+    ),
+    child: Row(
+      children: [
+        SizedBox(
+          width: 30,
+          child: Text(
+            "1",
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              color: colorScheme.primary,
+              fontWeight: FontWeight.bold,
+              fontSize: 16,
+            ),
+          ),
+        ),
+        const SizedBox(width: 10),
+        const CircleAvatar(radius: 22, backgroundColor: Colors.grey),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Text(
+            "Player 1",
+            style: TextStyle(
+              color: colorScheme.onSurface,
+              fontWeight: FontWeight.bold,
+              fontSize: 15,
+            ),
+          ),
+        ),
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            Text(
+              "1456",
+              style: TextStyle(
+                color: colorScheme.primary,
+                fontSize: width * 0.04,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            Text(
+              "PTS",
+              style: TextStyle(
+                color: colorScheme.onSurfaceVariant,
+                fontSize: width * 0.025,
+              ),
+            ),
+          ],
+        ),
+      ],
+    ),
+  );
+}


### PR DESCRIPTION
## Description (required)

ISSUE #10

Briefly describe the changes introduced in this pull request.

Problem Statement
During the event, hosts need a way to monitor how the game is the progressingg, and participants should be able to see how they rank compared to others. for that we need a game monitor dashboard for event hosts to track event progress and a leaderboard screen for participants to view rankings and scores.

Why is this important?
these screens help make the event more engaging and transparent.the game monitor allows hosts to see live activity and participation during the event, while the leaderboard keeps the participants motivated by showing their position and scores in the the real time.

Who will benefit?
Both hosts and participants.

Proposed Idea (Optional)
Game Monitor Screen

Display remaining event time
Show statistics like total players, active players, and moves made
Show live activity feed of recent player actions
Leaderboard Screen

Display top performers at the top
Show participant rankings with scores
Highlight the top three players
Update rankings as the game progresses
## Screenshots (for UI changes)



---

## Checklist

Before submitting this PR, please confirm the following:

- [ ] I have tested my changes locally
- [ ] I have linked the related issue
- [ ] No unrelated files are included in this PR

---